### PR TITLE
Improving depiction diagrams for dative bonds to metal (like HEM)

### DIFF
--- a/pdbeccdutils/core/component.py
+++ b/pdbeccdutils/core/component.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Tuple
 
 import rdkit
 import gemmi
-from rdkit.Chem import BRICS, Draw
+from rdkit.Chem import BRICS, Draw, BondType
 from rdkit.Chem.rdMolDescriptors import Properties
 from rdkit.Chem.Scaffolds import MurckoScaffold
 
@@ -495,9 +495,30 @@ class Component:
                 options.atomLabels[i] = atom_name
                 a.SetProp("molFileAlias", atom_name)
 
+        self._change_all_dative_bonds_to_zero()
+
         drawing.draw_molecule(
             self.mol2D, drawer, file_name, wedge_bonds, atom_highlight, bond_highlight
         )
+
+        self._change_all_dative_bonds_to_zero(reverse=True)
+
+    def _change_all_dative_bonds_to_zero(self, reverse: bool = False) -> None:
+        """
+        alters all bonds that are dative to zero order so that they will be
+        drawn with dotted lines rather than arrows
+
+        Args:
+            reverse (bool): alter zero order bonds back to dative
+        """
+        from_type = BondType.DATIVE
+        to_type = BondType.ZERO
+        if reverse:
+            from_type = BondType.ZERO
+            to_type = BondType.DATIVE
+        for bond in self.mol2D.GetBonds():
+            if bond.GetBondType() == from_type:
+                bond.SetBondType(to_type)
 
     def export_2d_annotation(self, file_name: str, wedge_bonds: bool = True) -> None:
         """Generates 2D depiction in JSON format with annotation of

--- a/pdbeccdutils/helpers/mol_tools.py
+++ b/pdbeccdutils/helpers/mol_tools.py
@@ -164,13 +164,13 @@ def fix_molecule(rwmol: rdkit.Chem.rdchem.RWMol):
             for metal_index, other_index in metal_atom_bonds:
                 metal_atom = rwmol.GetAtomWithIdx(metal_index)
                 other_atom = rwmol.GetAtomWithIdx(other_index)
-                # alter the bond to be dative towards the metal
+                # alter the bond to zero order - results in dotted line
                 if other_atom.GetExplicitValence() == valency:
                     rwmol.RemoveBond(metal_atom.GetIdx(),
                                      other_atom.GetIdx())
                     rwmol.AddBond(other_atom.GetIdx(),
                                   metal_atom.GetIdx(),
-                                  rdkit.Chem.BondType.DATIVE)
+                                  rdkit.Chem.BondType.ZERO)
             rwmol.UpdatePropertyCache()  # regenerates valence records
 
         attempts -= 1

--- a/pdbeccdutils/helpers/mol_tools.py
+++ b/pdbeccdutils/helpers/mol_tools.py
@@ -161,20 +161,17 @@ def fix_molecule(rwmol: rdkit.Chem.rdchem.RWMol):
             rdkit.Chem.SanitizeMol(
                 rwmol, sanitizeOps=rdkit.Chem.SanitizeFlags.SANITIZE_CLEANUP
             )
-
-            for metal_index, atom_index in metal_atom_bonds:
+            for metal_index, other_index in metal_atom_bonds:
                 metal_atom = rwmol.GetAtomWithIdx(metal_index)
-                erroneous_atom = rwmol.GetAtomWithIdx(atom_index)
-
-                # change the bond type to dative
-                bond = rwmol.GetBondBetweenAtoms(
-                    metal_atom.GetIdx(), erroneous_atom.GetIdx()
-                )
-                bond.SetBondType(rdkit.Chem.BondType.SINGLE)
-
-                if erroneous_atom.GetExplicitValence() == valency:
-                    erroneous_atom.SetFormalCharge(erroneous_atom.GetFormalCharge() + 1)
-                    metal_atom.SetFormalCharge(metal_atom.GetFormalCharge() - 1)
+                other_atom = rwmol.GetAtomWithIdx(other_index)
+                # alter the bond to be dative towards the metal
+                if other_atom.GetExplicitValence() == valency:
+                    rwmol.RemoveBond(metal_atom.GetIdx(),
+                                     other_atom.GetIdx())
+                    rwmol.AddBond(other_atom.GetIdx(),
+                                  metal_atom.GetIdx(),
+                                  rdkit.Chem.BondType.DATIVE)
+            rwmol.UpdatePropertyCache()  # regenerates valence records
 
         attempts -= 1
 

--- a/pdbeccdutils/helpers/mol_tools.py
+++ b/pdbeccdutils/helpers/mol_tools.py
@@ -164,13 +164,13 @@ def fix_molecule(rwmol: rdkit.Chem.rdchem.RWMol):
             for metal_index, other_index in metal_atom_bonds:
                 metal_atom = rwmol.GetAtomWithIdx(metal_index)
                 other_atom = rwmol.GetAtomWithIdx(other_index)
-                # alter the bond to zero order - results in dotted line
+                # alter the bond to be dative towards the metal -
                 if other_atom.GetExplicitValence() == valency:
                     rwmol.RemoveBond(metal_atom.GetIdx(),
                                      other_atom.GetIdx())
                     rwmol.AddBond(other_atom.GetIdx(),
                                   metal_atom.GetIdx(),
-                                  rdkit.Chem.BondType.ZERO)
+                                  rdkit.Chem.BondType.DATIVE)
             rwmol.UpdatePropertyCache()  # regenerates valence records
 
         attempts -= 1


### PR DESCRIPTION
This is a suggestion to use "ZERO order bonds" when there is a dative bond to a metal atom that results in a dotted line. For example HEM produces a diagram:


![HEM](https://github.com/PDBeurope/ccdutils/assets/8986794/de5e5929-ec56-48db-8384-94393e4c7c0c)

see comment below for the current diagram that uses atom charge adjustment rather than altering the bond order.